### PR TITLE
[Fix] Scheduler script in readme, no need to include zone file in every line of db

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The ad-blocking functionality should now be in effect. You can test the effectiv
     * Frequency: once a day
 1. For the "Task Settings" tab, fill in the fields as follow:
     * Send run details by email: `<your email here>`
-    * User defined script: `sudo /usr/local/bin/ad-blocker.sh`
+    * User defined script: `cd /tmp/; sudo /usr/local/bin/ad-blocker.sh`
 
 The run time should be set to run no more than once a day and be performed at an off-peak traffic time. The block lists don't change that frequently so be courteous to the provider. It is not strictly necessary to have the run details sent via email, but enabling it may help if there's a need to troubleshoot.
 

--- a/ad-blocker.sh
+++ b/ad-blocker.sh
@@ -110,7 +110,7 @@ apply_blacklist () {
     fi
 
     # domain not found, so append it to the list
-    echo "zone \"$Domain\" { type master; notify no; file \"/etc/zone/master/null.zone.file\"; };" >> "$BlockList"
+    echo "zone \"$Domain\" { type master; notify no;};" >> "$BlockList"
 
   done < "$BlackList"
 }


### PR DESCRIPTION
Tried to use this tool on my own Synology NAS in 2020. Went through different errors (Scheduled task was failing and go error message for every line of db load).

I had to change only two lines of code, based on issue comments and forum (Thank you all.)