### PR TITLE
Update Shell Script for DSM 7.0 and above

### DIFF
--- a/ad-blocker.sh
+++ b/ad-blocker.sh
@@ -186,7 +186,7 @@ update_zone_master () {
     echo '* IN A   127.0.0.1'; } > "$ZoneMasterFile"
 
   # reload the server config to pick up the changes
-  "${RootDir}"/script/reload.sh
+  "${RootDir}"/script/reload.sh null.zone.file
 }
 
 # Global vars for common paths

--- a/ad-blocker.sh
+++ b/ad-blocker.sh
@@ -78,7 +78,7 @@ fetch_blocklist () {
   # the "-O-" tells wget to send the file to standard out instead of a real file
   # this makes it suitable for piping and eliminates need for another temp file
   wget -O- "$BlocklistURL" | \
-    sed -e 's/null.zone.file/\/etc\/zone\/master\/null.zone.file/g' > "/tmp/ad-blocker.new"
+    sed -e 's/null.zone.file/\/var\/packages\/DNSServer\/target\/named\/etc\/zone\/master\/null.zone.file/g' > "/tmp/ad-blocker.new"
 }
 
 # user-specified list of domains to be blocked in addition to those from yoyo.org
@@ -156,10 +156,10 @@ update_zone_data () {
   # check for the include statement in the ZoneDataFile
   # if it is present do nothing, else append the include statement to the ZoneDataFile
   if [ -f "$ZoneDataDB" ] && [ -f "$ZoneDataFile" ]; then
-    Matches=$(grep 'include "/etc/zone/data/ad-blocker.db";' "$ZoneDataFile")
+    Matches=$(grep 'include "'${ZoneDataDir}'/ad-blocker.db";' "$ZoneDataFile")
     if [ -z "$Matches" ]; then
       echo '' >> "$ZoneDataFile"
-      echo 'include "/etc/zone/data/ad-blocker.db";' >> "$ZoneDataFile"
+      echo 'include "'${ZoneDataDir}'/ad-blocker.db";' >> "$ZoneDataFile"
     fi
   fi
 }


### PR DESCRIPTION
Two adjustments i had to apply, to make the import work. As it seems, with the newer DSM Version 7 the reload script needs the zone name as parameter. Also the absolute path to the master null.zone.file had to be specified. 